### PR TITLE
Feat/app_icon

### DIFF
--- a/src/ewwface.rs
+++ b/src/ewwface.rs
@@ -80,12 +80,13 @@ pub fn eww_create_notifications_value(cfg: &Config, notifs: &HashMap<u32, Notifi
         action_string.push(']');
 
         let widget_string = format!(
-            "(box ({} :notification \"{{\\\"actions\\\":{},\\\"application\\\":\\\"{}\\\",\\\"body\\\":\\\"{}\\\",\\\"icon\\\":\\\"{}\\\",\\\"id\\\":{},\\\"summary\\\":\\\"{}\\\"}}\"))",
+            "(box ({} :notification \"{{\\\"actions\\\":{},\\\"application\\\":\\\"{}\\\",\\\"body\\\":\\\"{}\\\",\\\"icon\\\":\\\"{}\\\",\\\"app_icon\\\":\\\"{}\\\",\\\"id\\\":{},\\\"summary\\\":\\\"{}\\\"}}\"))",
             cfg.eww_notification_widget,
             action_string,
             notif.1.app_name,
             notif.1.body,
             notif.1.icon,
+            notif.1.app_icon,
             notif.0,
             notif.1.summary,
         );

--- a/src/ewwface.rs
+++ b/src/ewwface.rs
@@ -136,7 +136,7 @@ pub fn eww_create_history_value(cfg: &Config, history: &[HistoryNotification]) -
     let history = history.iter().rev();
 
     for hist in history {
-        let widget_string = format!("({} :history \"{{\\\"app_name\\\":\\\"{}\\\",\\\"body\\\":\\\"{}\\\",\\\"icon\\\":\\\"{}\\\",\\\"summary\\\":\\\"{}\\\"}}\")", cfg.eww_history_widget, hist.app_name, hist.body, hist.icon, hist.summary);
+        let widget_string = format!("({} :history \"{{\\\"app_name\\\":\\\"{}\\\",\\\"body\\\":\\\"{}\\\",\\\"icon\\\":\\\"{}\\\",\\\"app_icon\\\":\\\"{}\\\",\\\"summary\\\":\\\"{}\\\"}}\")", cfg.eww_history_widget, hist.app_name, hist.body, hist.icon, hist.app_icon, hist.summary);
         history_text.push_str(&widget_string);
     }
     history_text.push(')');

--- a/src/notifdaemon.rs
+++ b/src/notifdaemon.rs
@@ -31,6 +31,7 @@ pub struct Notification {
 pub struct HistoryNotification {
     pub app_name: String,
     pub icon: String,
+    pub app_icon: String,
     pub summary: String,
     pub body: String,
 }
@@ -114,6 +115,7 @@ impl NotificationDaemon {
         let history_notification = HistoryNotification {
             app_name: app_name.to_string(),
             icon: icon.clone(),
+            app_icon: app_icon.clone(),
             summary: summary.to_string(),
             body: body.to_string(),
         };

--- a/src/notifdaemon.rs
+++ b/src/notifdaemon.rs
@@ -20,6 +20,7 @@ use crate::utils::{find_icon, save_icon};
 pub struct Notification {
     pub app_name: String,
     pub icon: String,
+    pub app_icon: String,
     pub summary: String,
     pub body: String,
     pub actions: Vec<(String, String)>,
@@ -82,6 +83,8 @@ impl NotificationDaemon {
                 }
             })
             .unwrap_or_else(|| app_icon.to_string());
+
+        let app_icon = find_icon(app_name, &config_main).unwrap_or("".into());
 
         let mut expire_timeout = expire_timeout;
         if expire_timeout < 0 {
@@ -146,6 +149,7 @@ impl NotificationDaemon {
         let notification = Notification {
             app_name: app_name.to_string(),
             icon: icon.clone(),
+            app_icon,
             actions,
             summary: summary.to_string(),
             body: body.to_string(),


### PR DESCRIPTION
I thought that the `app_name` property given by DBus was under-utilized and that we could use [icon_loader](https://docs.rs/icon-loader) (wrapped by [find_icon](https://github.com/Dr-42/end-rs/blob/51ea37923e882401eabe9d5cddbe23f99cfabbaa/src/utils.rs#L7)) to get the application icon and give it as a widget parameter.

This PR adds a new `app_icon` parameter to the *widget* parameters that can be utilized to display the app icon:

![image](https://github.com/user-attachments/assets/030fc4e1-797f-4551-a9fa-7e71eca5dfca)
<details>
<summary> Show notify-send command </summary>

```sh
notify-send -a Element -i ~/Images/Icons/jason-momoa.png "Jason Momoa replied" --action 'default=Reply' "Yo the last Aquaman movie was trash."
```

</details>

(example usage can be found in my [dotfiles](https://github.com/GaspardCulis/dotfiles/blob/main/bar/eww/notification/widget.yuck))

If no icon could be found, `app_icon` defaults to an empty string. 
Added both in the **notification** *widget_string* and in the **history_notification** *widget_string*.

Also I did not bother updating the example eww configs in the repo.