### PR TITLE
Feat/nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import <nixpkgs> { } }:
+let manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
+in
+pkgs.rustPlatform.buildRustPackage rec {
+  pname = manifest.name;
+  version = manifest.version;
+  cargoLock.lockFile = ./Cargo.lock;
+  src = pkgs.lib.cleanSource ./.;
+}
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1726755586,
+        "narHash": "sha256-PmUr/2GQGvFTIJ6/Tvsins7Q43KTMvMFhvG6oaYK+Wk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c04d5652cfa9742b1d519688f65d1bbccea9eb7e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "Eww notification daemon (in Rust)";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      pkgsFor = nixpkgs.legacyPackages;
+    in {
+      packages = forAllSystems (system: {
+        default = pkgsFor.${system}.callPackage ./. { };
+      });
+    };
+}
+


### PR DESCRIPTION
Added Nix relevant config.

This makes `end-rs` available as a [nix flake](https://nixos.wiki/wiki/flakes) input. See my [current dotfiles](https://github.com/GaspardCulis/dotfiles/blob/92675c329d39a03dc67446a99dae534dd7197e83/flake.nix#L25) for an example (currently pointing at my own `end-rs` fork).